### PR TITLE
Fixed Persistent Mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,10 @@ ifeq ($(UNICORN_AFL),yes)
 UNICORN_CFLAGS += -DUNICORN_AFL
 endif
 
+ifeq ($(AFL_DEBUG),yes)
+UNICORN_CFLAGS += -DAFL_DEBUG
+endif
+
 ifeq ($(CROSS),)
 CC ?= cc
 AR ?= ar

--- a/afl-unicorn-cpu-inl.h
+++ b/afl-unicorn-cpu-inl.h
@@ -34,6 +34,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unicorn.h>
+#include "types.h"
 #include "afl-unicorn-common.h"
 
 /* We use one additional file descriptor to relay "needs translation"
@@ -48,20 +49,17 @@
 #define _R(pipe) ((pipe)[0])
 #define _W(pipe) ((pipe)[1])
 
-/* Channel from child (_W) to parent (_R) for tcg translation cache */
-static int p_tsl[2] = {0}; 
-//static __thread unsigned long prev_loc = 0;
-
 
 /* Function declarations. */
 
 static void        afl_setup(struct uc_struct*);
 static inline uc_afl_ret afl_forkserver(CPUArchState*);
 static inline void afl_maybe_log(struct uc_struct*, unsigned long);
+static int afl_find_wifsignaled_id(void);
 
-static bool afl_wait_tsl(CPUArchState*, int);
+static enum afl_child_ret afl_handle_child_requests(CPUArchState*);
 static void afl_request_tsl(struct uc_struct* uc, target_ulong, target_ulong, uint64_t);
-static uc_afl_ret afl_request_next(void);
+static uc_afl_ret afl_request_next(struct uc_struct* uc, bool found_crash);
 
 // static TranslationBlock* tb_find_slow(CPUArchState*, target_ulong, target_ulong, uint64_t);
 
@@ -75,14 +73,22 @@ struct afl_tsl {
 
 };
 
-/* Instead of adding a field, reuse this special one.
-  this should have less overhead. */
+/* Current state, as fowarded from forkserver child to parent */
 
-static const struct afl_tsl AFL_NEXT_TESTCASE_REQUEST = {
-  .pc = (target_ulong) FF16,
-  .cs_base = (target_ulong) FF16,
-  .flags = FF16,
+enum afl_child_ret {
+
+  // Persistent 
+  AFL_CHILD_NEXT,
+  // Crash discovered but still alive in persistent mode
+  AFL_CHILD_FOUND_CRASH,
+  // Read again, one afl_tsl struct.
+  AFL_CHILD_TSL_REQUEST,
+  // Child no longer there. Read status code.
+  AFL_CHILD_EXITED,
+
 };
+
+static int wifsignaled;
 
 /*************************
  * ACTUAL IMPLEMENTATION *
@@ -92,7 +98,11 @@ static const struct afl_tsl AFL_NEXT_TESTCASE_REQUEST = {
 
 static void afl_setup(struct uc_struct* uc) {
 
-  char *id_str = getenv(SHM_ENV_VAR), *inst_r = getenv("AFL_INST_RATIO");
+  char *id_str = getenv(SHM_ENV_VAR);
+  char *inst_r = getenv("AFL_INST_RATIO");
+ 
+  // A value we can use to tell AFL our persistent mode found a crash
+  wifsignaled = afl_find_wifsignaled_id();
 
   int shm_id;
 
@@ -118,19 +128,10 @@ static void afl_setup(struct uc_struct* uc) {
     shm_id = atoi(id_str);
     uc->afl_area_ptr = shmat(shm_id, NULL, 0);
     uc->afl_prev_loc = 0;
+    uc->afl_area_ptr[0] = 1;
 
     if (uc->afl_area_ptr == (void*)-1) exit(1);
     
-    /*For persistent mode, we want the map to be emtpy on every fork.
-      This has to be done by the initial caller, now.
-      */
-    //memset(uc->afl_area_ptr, 0, MAP_SIZE); 
-
-    /* With AFL_INST_RATIO set to a low value, we want to touch the bitmap
-       so that the parent doesn't give up on us. */
-
-    if (inst_r) uc->afl_area_ptr[0] = 1;
-
   }
 
   /* Maintain for compatibility */
@@ -143,6 +144,20 @@ static void afl_setup(struct uc_struct* uc) {
 
 }
 
+// Some dirty hack to come up with a valid statuscode that AFL will just accept.
+
+static int afl_find_wifsignaled_id(void) {
+
+  int ret; // A faux status code that AFL will accept as signaled/crashed. 1 on linux.
+  while (!(WIFSIGNALED(ret))) ret++;
+
+#if defined(AFL_DEBUG)
+  printf("[d] wifsignaled is %d (WIFSIGNALED(x)=%d)\n", ret, WIFSIGNALED(ret));
+#endif
+
+  return ret;
+
+}
 
 /* Fork server logic, invoked by calling uc_afl_forkserver_start.
    Roughly follows https://github.com/vanhauser-thc/AFLplusplus/blob/c83e8e1e6255374b085292ba8673efdca7388d76/llvm_mode/afl-llvm-rt.o.c#L130 
@@ -150,9 +165,10 @@ static void afl_setup(struct uc_struct* uc) {
 
 static inline uc_afl_ret afl_forkserver(CPUArchState* env) {
 
-  static unsigned char tmp[4];
+  static unsigned char tmp[4] = {0};
   pid_t   child_pid;
-  bool child_alive = false;
+  enum afl_child_ret child_ret = AFL_CHILD_EXITED;
+  bool first_round = true;
 
   if (!env->uc->afl_area_ptr) return UC_AFL_RET_NO_AFL;
 
@@ -176,27 +192,40 @@ static inline uc_afl_ret afl_forkserver(CPUArchState* env) {
     condition and afl-fuzz already issued SIGKILL, write off the old
     process. */
 
-    if (child_alive && was_killed) {
+    if ((child_ret == AFL_CHILD_NEXT || child_ret == AFL_CHILD_EXITED) && was_killed) {
+    
+#if defined(AFL_DEBUG)
+      printf("[d] Child was killed by AFL in the meantime.\n");
+#endif
 
-      child_alive = false;
+      child_ret = AFL_CHILD_EXITED;
       if (waitpid(child_pid, &status, 0) < 0) {
-        perror("[!] Error waiting for child! ");
+        perror("[!] Error waiting for child!");
         return UC_AFL_RET_ERROR;
       }
 
     }
 
-    if (!child_alive) {
+    if (child_ret == AFL_CHILD_EXITED) {
 
       /* Child dead. Establish new a channel with child to grab translation commands.
-        We'll read from _R(p_tsl), child will write to _W(p_tsl). */
+        We'll read from _R(afl_child_pipe), child will write to _W(afl_child_pipe). */
 
       /* close the read fd of previous round. */
 
-      if _R(p_tsl) close(_R(p_tsl));
+      if _R(env->uc->afl_child_pipe) {
+        close(_R(env->uc->afl_child_pipe));
+        close(_W(env->uc->afl_parent_pipe));
+      }
 
-      if (pipe(p_tsl)) {
-        perror("[!] Error creating pipe to child. ");
+      if (pipe(env->uc->afl_child_pipe)) {
+        perror("[!] Error creating pipe to child");
+        return UC_AFL_RET_ERROR;
+      }
+      if (pipe(env->uc->afl_parent_pipe)) {
+        perror("[!] Error creating pipe to parent");
+        close(_R(env->uc->afl_child_pipe));
+        close(_W(env->uc->afl_child_pipe));
         return UC_AFL_RET_ERROR;
       }
 
@@ -210,32 +239,54 @@ static inline uc_afl_ret afl_forkserver(CPUArchState* env) {
 
       /* In child process: close fds, resume execution. */
 
-      if (!child_pid) {
+      if (!child_pid) { // New child
 
         signal(SIGCHLD, old_sigchld_handler);
-
-        close(FORKSRV_FD);
+        // FORKSRV_FD is for communication with AFL, we don't need it in the child.
+        close(FORKSRV_FD); 
         close(FORKSRV_FD + 1);
-        close(_R(p_tsl));
+        close(_R(env->uc->afl_child_pipe));
+        close(_W(env->uc->afl_parent_pipe));
         env->uc->afl_child_request_next = afl_request_next;
+
+        memset(env->uc->afl_area_ptr, 0, MAP_SIZE);
+        MEM_BARRIER(); // Make very sure everything has been written to the map at this point
+
+        if (!first_round) {
+
+          // For persistent mode: Clear the map manually after forks.
+          memset(env->uc->afl_area_ptr, 0, MAP_SIZE);
+
+        } else {
+          // For persistent mode: Clear the map manually after forks.
+          //memset(env->uc->afl_area_ptr, 0, MAP_SIZE);
+
+          first_round = false;
+        }
+
+        env->uc->afl_prev_loc = 0;
+        // Tell AFL we're alive
+        env->uc->afl_area_ptr[0] = 1;
+
         return UC_AFL_RET_CHILD;
 
-      } else {
+      } else { // parent for new child
 
-        /* If we don't close this in parent, we don't get notified on p_tsl once child is gone. */
+        /* If we don't close this in parent, we don't get notified on afl_child_pipe once child is gone. */
 
-        close(_W(p_tsl));
+        close(_W(env->uc->afl_child_pipe));
+        close(_R(env->uc->afl_parent_pipe));
 
       }
 
-    } else {
+    } else { // parent, in persistent mode
 
       /* Special handling for persistent mode: if the child is alive but
-         currently stopped, simply restart it with SIGCONT. */
+         currently stopped, simply restart it with a write to afl_parent_pipe. */
 
-      if (kill(child_pid, SIGCONT) < 0) {
+      if (write(_W(env->uc->afl_parent_pipe), tmp, 4) != 4) {
 
-        perror("[!] Child didn't continue. ");
+        fprintf(stderr,"[!] Child died when we tried to resume it\n");
         return UC_AFL_RET_ERROR;
 
       }
@@ -248,28 +299,35 @@ static inline uc_afl_ret afl_forkserver(CPUArchState* env) {
       return UC_AFL_RET_FINISHED;
     }
 
-    /* Collect translation requests until child is finished (true) 
-       or 0xdead (false) */
+    /* Collect translation requests until child finishes a run or dies */
 
-    child_alive = afl_wait_tsl(env, _R(p_tsl));
+    child_ret = afl_handle_child_requests(env);
 
-    /* Get and relay exit status to parent. 
-       No need to wait for WUNTRACED if child is not alive. */
+    if (child_ret == AFL_CHILD_NEXT) {
 
-    if (waitpid(child_pid, &status, child_alive ? WUNTRACED: 0) < 0) {
+      /* Child asks for next in persistent mode  */
 
-      // Zombie Child could not be collected. Scary!
-      perror("[!] The child's exit code could not be determined. ");
-      return UC_AFL_RET_ERROR;
+      status = 0;
+
+    } else if (child_ret == AFL_CHILD_FOUND_CRASH) {
+
+      /* WIFSIGNALED(wifsignaled) == 1 -> tells AFL the child crashed (even though it's still alive for persistent mode) */
+      
+      status = wifsignaled;
+
+    } else if (child_ret == AFL_CHILD_EXITED) {
+
+      /* If child exited, get and relay exit status to parent through waitpid. */
+
+      if (waitpid(child_pid, &status, 0) < 0) {
+
+        // Zombie Child could not be collected. Scary!
+        perror("[!] The child's exit code could not be determined. ");
+        return UC_AFL_RET_ERROR;
+
+      }
 
     }
-
-
-    /* In persistent mode, the child stops itself with SIGSTOP to indicate
-       a successful run. In this case, we want to wake it up without forking
-       again. */
-
-    child_alive = child_alive && WIFSTOPPED(status);
 
     /* Relay wait status to AFL pipe, then loop back. */
 
@@ -304,11 +362,15 @@ static inline void afl_maybe_log(struct uc_struct* uc, unsigned long cur_loc) {
 
   INC_AFL_AREA(afl_idx);
 
+#if defined(AFL_DEBUG)
+  printf("[d] At loc 0x%lx: prev: 0x%lx, afl_idx: %lu, map[afl_idx]: %d\n", cur_loc, uc->afl_prev_loc, afl_idx, afl_area_ptr[afl_idx]);
+#endif
+
   uc->afl_prev_loc = cur_loc >> 1;
 
 }
 
-/* This code is invoked whenever QEMU decides that it doesn't have a
+/* This code is invoked whenever Unicorn decides that it doesn't have a
    translation of a particular block and needs to compute it. When this happens,
    we tell the parent to mirror the operation, so that the next fork() has a
    cached copy. */
@@ -319,50 +381,109 @@ static inline void afl_request_tsl(struct uc_struct* uc, target_ulong pc, target
 
   if (uc->afl_child_request_next == NULL) return;
 
-  struct afl_tsl t = {0};
+  enum afl_child_ret tsl_req = AFL_CHILD_TSL_REQUEST;
 
-  t.pc = pc;
-  t.cs_base = cb;
-  t.flags = flags;
+  struct afl_tsl t = {
+    .pc = pc,
+    .cs_base = cb,
+    .flags = flags,
+  };
 
-  if (write(_W(p_tsl), &t, sizeof(struct afl_tsl)) != sizeof(struct afl_tsl))
-    return;
+#if defined(AFL_DEBUG)
+  printf("Requesting tsl, pc=0x%lx, cb=0x%lx, flags=0x%lx\n", (uint64_t) pc, (uint64_t) cb, flags);
+#endif
+
+  // We write tsl requests in two steps but that's fine since cache requests are not very common over the time of fuzzing.
+
+  if ((write(_W(uc->afl_child_pipe), &tsl_req, sizeof(enum afl_child_ret)) != sizeof(enum afl_child_ret)) 
+      || write(_W(uc->afl_child_pipe), &t, sizeof(struct afl_tsl)) != sizeof(struct afl_tsl)) {
+
+    fprintf(stderr, "Error writing to child pipe. Parent dead?\n");
+
+  }
 
 }
 
 /* This code is invoked whenever the child decides that it is done with one fuzz-case. */
 
-static uc_afl_ret afl_request_next(void) {
+static uc_afl_ret afl_request_next(struct uc_struct* uc, bool crash_found) {
 
-  if (write(_W(p_tsl), &AFL_NEXT_TESTCASE_REQUEST, sizeof(struct afl_tsl)) != sizeof(struct afl_tsl)) return UC_AFL_RET_ERROR;
+  enum afl_child_ret msg = crash_found? AFL_CHILD_FOUND_CRASH : AFL_CHILD_NEXT;
+  static unsigned char tmp[4] = {0};
+
+#if defined(AFL_DEBUG)
+  printf("[d] request next. crash found: %s\n", crash_found ? "true": "false");
+#endif
+
+  MEM_BARRIER(); // Make very sure everything has been written to the map at this point
+
+  if (write(_W(uc->afl_child_pipe), &msg, sizeof(msg)) != sizeof(msg)) {
+
+    fprintf(stderr, "[!] Error writing to parent pipe. Parent dead?\n");
+    return UC_AFL_RET_ERROR;
+
+  }
+
+  // Once the parent has written something, the next persistent loop starts.
+  // The parent itself will wait for AFL to signal the new testcases is available.
+  if (read(_R(uc->afl_parent_pipe), &tmp, 4) != 4) {
+
+    fprintf(stderr, "[!] Error reading from parent pipe. Parent dead?\n");
+    return UC_AFL_RET_ERROR;
+
+  }
+
+  memset(uc->afl_area_ptr, 0, MAP_SIZE);
+  MEM_BARRIER(); // Also make sure nothing read before this point.
+
+  // Start with a clean slate.
+  uc->afl_prev_loc = 0;
+  uc->afl_area_ptr[0] = 1;
 
   return UC_AFL_RET_CHILD;
 
 }
 
 
-/* This is the other side of the same channel. Since timeouts are handled by
-   afl-fuzz simply killing the child, we can just wait until the pipe breaks.
-   For returns true if child is still alive, else false */
+/* This is the reading side of afl_child_pipe. It will handle persistent mode and (tsl) cache requests.
+  Since timeouts are handled by afl-fuzz simply killing the child, we can just wait until the pipe breaks.
+  For persistent mode, we will also receive child responses over this chanel.
+  For persistent mode, if child is still alive, this will return if the child crashed or not */
 
-static bool afl_wait_tsl(CPUArchState* env, int fd) {
+static enum afl_child_ret afl_handle_child_requests(CPUArchState* env) {
 
+  enum afl_child_ret child_msg;
   struct afl_tsl t;
 
   while (1) {
 
     /* Broken pipe means it's time to return to the fork server routine. */
 
-    if (read(fd, &t, sizeof(struct afl_tsl)) != sizeof(struct afl_tsl)) return false; // child is dead.
+    if (read(_R(env->uc->afl_child_pipe), &child_msg, sizeof(enum afl_child_ret)) != sizeof(enum afl_child_ret)) return AFL_CHILD_EXITED; // child is dead.
 
-    /* We chose FF16 (MAX_INT64) for each member of our afl_next_testcase_request struct. */
+    if (child_msg == AFL_CHILD_NEXT || child_msg == AFL_CHILD_FOUND_CRASH) {
 
-    if (t.pc == AFL_NEXT_TESTCASE_REQUEST.pc && t.cs_base == AFL_NEXT_TESTCASE_REQUEST.cs_base 
-        && t.flags == AFL_NEXT_TESTCASE_REQUEST.flags) return true; // child is still alive!
+      // Forward if child found a crash or not, for persistent mode.
+      return child_msg;
 
-    tb_find_slow(env, t.pc, t.cs_base, t.flags);
+    } else if (child_msg == AFL_CHILD_TSL_REQUEST) {
+
+      // TODO: Add option to disable cache for self-modifying code? // Ignore code that has not been loaded?
+
+      // Child will send a tsl request next, that we have to cache.
+      if (read(_R(env->uc->afl_child_pipe), &t, sizeof(struct afl_tsl)) != sizeof(struct afl_tsl)) return AFL_CHILD_EXITED; // child is dead.
+
+      // Cache.
+      tb_find_slow(env, t.pc, t.cs_base, t.flags);
+
+    } else {
+      
+      fprintf(stderr, "[!] Unexpected response by child! %d. Please report this as bug for unicornafl.\n"
+                      "    Expected one of {AFL_CHILD_NEXT: %d, AFL_CHILD_FOUND_CRASH: %d, AFL_CHILD_TSL_REQUEST: %d}.\n", 
+                      child_msg, AFL_CHILD_NEXT, AFL_CHILD_FOUND_CRASH, AFL_CHILD_TSL_REQUEST);
+
+    }
 
   }
 
 }
-

--- a/afl-unicorn-cpu-inl.h
+++ b/afl-unicorn-cpu-inl.h
@@ -50,7 +50,7 @@
 
 /* Channel from child (_W) to parent (_R) for tcg translation cache */
 static int p_tsl[2] = {0}; 
-static __thread unsigned long prev_loc = 0;
+//static __thread unsigned long prev_loc = 0;
 
 
 /* Function declarations. */
@@ -300,11 +300,11 @@ static inline void afl_maybe_log(struct uc_struct* uc, unsigned long cur_loc) {
 
   if (cur_loc >= uc->afl_inst_rms) return;
 
-  register uintptr_t afl_idx = cur_loc ^ prev_loc;
+  register uintptr_t afl_idx = cur_loc ^ uc->afl_prev_loc;
 
   INC_AFL_AREA(afl_idx);
 
-  prev_loc = cur_loc >> 1;
+  uc->afl_prev_loc = cur_loc >> 1;
 
 }
 

--- a/afl-unicorn-cpu-translate-inl.h
+++ b/afl-unicorn-cpu-translate-inl.h
@@ -32,8 +32,8 @@
 
 #include "config.h"
 
-static void afl_gen_compcov(TCGContext *s, uint64_t cur_loc, TCGv_i64 arg1,
-                            TCGv_i64 arg2, TCGMemOp ot, int is_imm) {
+static void afl_gen_compcov(TCGContext *s, uint64_t cur_loc, TCGv arg1,
+                            TCGv arg2, TCGMemOp ot, int is_imm) {
 
   if (!s->uc->afl_compcov_level || !s->uc->afl_area_ptr) return;
 
@@ -46,9 +46,9 @@ static void afl_gen_compcov(TCGContext *s, uint64_t cur_loc, TCGv_i64 arg1,
 
   switch (ot) {
 
-    case MO_64: gen_afl_compcov_log_64(s, cur_loc, arg1, arg2); break;
-    case MO_32: gen_afl_compcov_log_32(s, cur_loc, arg1, arg2); break;
-    case MO_16: gen_afl_compcov_log_16(s, cur_loc, arg1, arg2); break;
+    case MO_64: gen_afl_compcov_log_64(s, cur_loc, (TCGv_i64)arg1, (TCGv_i64)arg2); break;
+    case MO_32: gen_afl_compcov_log_32(s, cur_loc, (TCGv_i32)arg1, (TCGv_i32)arg2); break;
+    case MO_16: gen_afl_compcov_log_16(s, cur_loc, (TCGv_i32)arg1, (TCGv_i32)arg2); break;
     default: return;
 
   }

--- a/afl-unicorn-cpu-translate-inl.h
+++ b/afl-unicorn-cpu-translate-inl.h
@@ -32,6 +32,29 @@
 
 #include "config.h"
 
+/* These are executed on code generation. Execution is in afl-unicorn-tcg-runtime-inl.h */
+/* Roughly afl_gen_maybe_log -> gen_afl_maybe_log -> emit HELPER(afl_maybe_log) -> call afl_maybe_log */
+
+static void afl_gen_maybe_log(TCGContext *s, uint64_t cur_loc) {
+
+  if (!s->uc->afl_area_ptr) return;
+
+  /* "Hash" */
+
+  cur_loc = (cur_loc >> 4) ^ (cur_loc << 8);
+  cur_loc &= MAP_SIZE - 7;
+
+  /* Implement probabilistic instrumentation by looking at scrambled block
+     address. This keeps the instrumented locations stable across runs. */
+
+  if (cur_loc >= s->uc->afl_inst_rms) return;
+
+    gen_afl_maybe_log(s, cur_loc);
+
+}
+
+// Currently only arm32 and x86. We undefine it for others to silence unused func compiler warnings.
+#if defined(ARCH_HAS_COMPCOV)
 static void afl_gen_compcov(TCGContext *s, uint64_t cur_loc, TCGv arg1,
                             TCGv arg2, TCGMemOp ot, int is_imm) {
 
@@ -54,4 +77,4 @@ static void afl_gen_compcov(TCGContext *s, uint64_t cur_loc, TCGv arg1,
   }
 
 }
-
+#endif

--- a/afl-unicorn-tcg-op-inl.h
+++ b/afl-unicorn-tcg-op-inl.h
@@ -31,7 +31,7 @@
  */
 
 static inline void gen_afl_compcov_log_16(TCGContext *tcg_ctx, uint64_t cur_loc,
-                                          TCGv_i64 arg1, TCGv_i64 arg2) {
+                                          TCGv_i32 arg1, TCGv_i32 arg2) {
 
   TCGv_ptr tuc = tcg_const_ptr(tcg_ctx, tcg_ctx->uc);
   TCGv_i64 tcur_loc = tcg_const_i64(tcg_ctx, cur_loc);
@@ -40,7 +40,7 @@ static inline void gen_afl_compcov_log_16(TCGContext *tcg_ctx, uint64_t cur_loc,
 }
 
 static inline void gen_afl_compcov_log_32(TCGContext *tcg_ctx, uint64_t cur_loc,
-                                          TCGv_i64 arg1, TCGv_i64 arg2) {
+                                          TCGv_i32 arg1, TCGv_i32 arg2) {
 
   TCGv_ptr tuc = tcg_const_ptr(tcg_ctx, tcg_ctx->uc);
   TCGv_i64 tcur_loc = tcg_const_i64(tcg_ctx, cur_loc);

--- a/afl-unicorn-tcg-op-inl.h
+++ b/afl-unicorn-tcg-op-inl.h
@@ -30,6 +30,14 @@
 
  */
 
+static inline void gen_afl_maybe_log(TCGContext *tcg_ctx, uint64_t cur_loc) {
+
+  TCGv_ptr tuc = tcg_const_ptr(tcg_ctx, tcg_ctx->uc);
+  TCGv_i64 tcur_loc = tcg_const_i64(tcg_ctx, cur_loc);
+  gen_helper_afl_maybe_log(tcg_ctx, tuc, tcur_loc);
+
+}
+
 static inline void gen_afl_compcov_log_16(TCGContext *tcg_ctx, uint64_t cur_loc,
                                           TCGv_i32 arg1, TCGv_i32 arg2) {
 

--- a/afl-unicorn-tcg-runtime-inl.h
+++ b/afl-unicorn-tcg-runtime-inl.h
@@ -33,8 +33,8 @@
 #include "uc_priv.h"
 #include "afl-unicorn-common.h"
 
-void HELPER(afl_compcov_log_16)(void* uc_ptr, uint64_t cur_loc, uint64_t arg1,
-                                uint64_t arg2) {
+void HELPER(afl_compcov_log_16)(void* uc_ptr, uint64_t cur_loc, uint32_t arg1,
+                                uint32_t arg2) {
 
   u8* afl_area_ptr = ((struct uc_struct*)uc_ptr)->afl_area_ptr;
 
@@ -42,8 +42,8 @@ void HELPER(afl_compcov_log_16)(void* uc_ptr, uint64_t cur_loc, uint64_t arg1,
 
 }
 
-void HELPER(afl_compcov_log_32)(void* uc_ptr, uint64_t cur_loc, uint64_t arg1,
-                                uint64_t arg2) {
+void HELPER(afl_compcov_log_32)(void* uc_ptr, uint64_t cur_loc, uint32_t arg1,
+                                uint32_t arg2) {
 
   u8* afl_area_ptr = ((struct uc_struct*)uc_ptr)->afl_area_ptr;
 

--- a/config.mk
+++ b/config.mk
@@ -8,7 +8,7 @@
 # Compile with debug info when you want to debug code.
 # Change this to 'no' for release edition.
 
-UNICORN_DEBUG ?= no
+UNICORN_DEBUG ?= yes
 
 ################################################################################
 # Specify which archs you want to compile in. By default, we build all archs.

--- a/config.mk
+++ b/config.mk
@@ -10,9 +10,6 @@
 
 UNICORN_DEBUG ?= no
 
-################################################################################
-# Enable additional debug logging for unicornafl
-AFL_DEBUG ?= no
 
 ################################################################################
 # Specify which archs you want to compile in. By default, we build all archs.
@@ -38,3 +35,10 @@ UNICORN_SHARED ?= yes
 # Changing 'UNICORN_AFLL = yes' to 'UNICORN_AFL = no' disables AFL instrumentation
 
 UNICORN_AFL ?= yes
+
+
+################################################################################
+# Enable debug logging for unicornafl
+#
+AFL_DEBUG ?= no
+

--- a/config.mk
+++ b/config.mk
@@ -8,7 +8,11 @@
 # Compile with debug info when you want to debug code.
 # Change this to 'no' for release edition.
 
-UNICORN_DEBUG ?= yes
+UNICORN_DEBUG ?= no
+
+################################################################################
+# Enable additional debug logging for unicornafl
+AFL_DEBUG ?= no
 
 ################################################################################
 # Specify which archs you want to compile in. By default, we build all archs.

--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -256,7 +256,8 @@ struct uc_struct {
 #ifdef UNICORN_AFL
     uc_args_int_uc_t afl_forkserver_start; // function to start afl forkserver
     uc_afl_ret_void_t afl_child_request_next; // function from child to ask for new testcase (if in child)
-    unsigned char *afl_area_ptr; // map, shared with afl, to report coverage feedback etc. during runs
+    uint8_t *afl_area_ptr; // map, shared with afl, to report coverage feedback etc. during runs
+    uint64_t afl_prev_loc; // previous location
     int afl_compcov_level; // how much compcove we want
     unsigned int afl_inst_rms; 
     size_t exit_count; // number of exits set in afl_fuzz or afl_forkserver

--- a/include/uc_priv.h
+++ b/include/uc_priv.h
@@ -83,8 +83,8 @@ typedef uint64_t (*uc_mem_redirect_t)(uint64_t address);
 // validate if Unicorn supports hooking a given instruction
 typedef bool(*uc_insn_hook_validate)(uint32_t insn_enum);
 
-// we use this as shortcut deep inside uc_afl for uc_afl_next()
-typedef uc_afl_ret(*uc_afl_ret_void_t)(void);
+// we use this as shortcut deep inside uc_afl for the arch specific uc_afl_next(uc, bool)
+typedef uc_afl_ret(*uc_afl_ret_uc_bool_t)(struct uc_struct*, bool);
 
 struct hook {
     int type;            // UC_HOOK_*
@@ -255,7 +255,9 @@ struct uc_struct {
     
 #ifdef UNICORN_AFL
     uc_args_int_uc_t afl_forkserver_start; // function to start afl forkserver
-    uc_afl_ret_void_t afl_child_request_next; // function from child to ask for new testcase (if in child)
+    uc_afl_ret_uc_bool_t afl_child_request_next; // function from child to ask for new testcase (if in child)
+    int afl_child_pipe[2]; // pipe used to send information from child process to forkserver
+    int afl_parent_pipe[2]; // pipe used to send information from parent to child in forkserver
     uint8_t *afl_area_ptr; // map, shared with afl, to report coverage feedback etc. during runs
     uint64_t afl_prev_loc; // previous location
     int afl_compcov_level; // how much compcove we want

--- a/include/unicorn/unicorn.h
+++ b/include/unicorn/unicorn.h
@@ -588,7 +588,7 @@ typedef bool (*uc_afl_cb_validate_crash_t)(uc_engine *uc, uc_err unicorn_result,
 /*
  The main fuzzer.
  Starts uc_afl_forkserver(), then beginns a persistent loop.
- Reads input, calls the place_input callback, emulates, uc_afl_next(), repeats.
+ Reads input, calls the place_input callback, emulates, uc_afl_next(...), repeats.
  If unicorn errors out, will call the validate_crash_callback, if set.
  Will only retrun in the parent after the whole fuzz thing has been finished and afl died.
  The child processes never return from here.
@@ -678,10 +678,13 @@ int uc_afl_emu_start(uc_engine *uc);
   (similar to what __afl_persistent loop // __LOOP does)
   uc_afl_fuzz() already makes use of this function under the hood.
 
+  @uc: handle returned by uc_open()
+  @crash_found: true, if the previous round found a crash (will be reported to afl before the next testcase), false otherwise
+
   @return UC_AFL_RET_ERROR on error (if uc_afl_forkserver(...) was not called or parent died), else UC_AFL_RET_CHILD.
 */
 UNICORN_EXPORT
-uc_afl_ret uc_afl_next(uc_engine *uc);
+uc_afl_ret uc_afl_next(uc_engine *uc, bool crash_found);
 
 #endif
 

--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -24,15 +24,15 @@
 
 #include "uc_priv.h"
 
-#if defined(UNICORN_AFL)
-#include "../afl-unicorn-cpu-inl.h"
-#endif 
-
 static tcg_target_ulong cpu_tb_exec(CPUState *cpu, uint8_t *tb_ptr);
 static TranslationBlock *tb_find_slow(CPUArchState *env, target_ulong pc,
         target_ulong cs_base, uint64_t flags);
 static TranslationBlock *tb_find_fast(CPUArchState *env);
 static void cpu_handle_debug_exception(CPUArchState *env);
+
+#if defined(UNICORN_AFL)
+#include "../afl-unicorn-cpu-inl.h"
+#endif 
 
 void cpu_loop_exit(CPUState *cpu)
 {

--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -289,10 +289,6 @@ int cpu_exec(struct uc_struct *uc, CPUArchState *env)   // qq
                             next_tb & TB_EXIT_MASK, tb);
                 }
 
-#if defined(UNICORN_AFL)
-                afl_maybe_log(env->uc, tb->pc); 
-#endif
-
                 /* cpu_interrupt might be called while translating the
                    TB, but before it is linked into a potentially
                    infinite loop and becomes env->current_tb. Avoid
@@ -456,9 +452,6 @@ not_found:
 #if defined(UNICORN_AFL)
     /* There seems to be no chaining in unicorn ever? :( */
     afl_request_tsl(env->uc, pc, cs_base, flags);
-#if defined(AFL_DEBUG)
-    printf(" finished 0x%lx.\n", (uint64_t) pc);
-#endif
 #endif
 
 found:

--- a/qemu/cpu-exec.c
+++ b/qemu/cpu-exec.c
@@ -344,7 +344,9 @@ int cpu_exec(struct uc_struct *uc, CPUArchState *env)   // qq
     // TODO: optimize this for better performance
 #if defined (UNICORN_AFL)
     if (uc->afl_area_ptr) {
-        //printf("[d] Found area ptr, not flushing\n");
+#if defined(AFL_DEBUG)
+        printf("[d] Found area ptr, not flushing translation cache.\n");
+#endif
     }
     else
 #endif
@@ -445,18 +447,24 @@ static TranslationBlock *tb_find_slow(CPUArchState *env, target_ulong pc,
         ptb1 = &tb->phys_hash_next;
     }
 not_found:
-    //printf("[d] translating 0x%llx...", pc);
+#if defined(AFL_DEBUG)
+    printf("[d] translating 0x%lx...", (uint64_t) pc);
+#endif
     /* if no translated code available, then translate it now */
     tb = tb_gen_code(cpu, pc, cs_base, (int)flags, 0);   // qq
     
 #if defined(UNICORN_AFL)
     /* There seems to be no chaining in unicorn ever? :( */
     afl_request_tsl(env->uc, pc, cs_base, flags);
-    //printf(" finished 0x%llx.", pc);
+#if defined(AFL_DEBUG)
+    printf(" finished 0x%lx.\n", (uint64_t) pc);
+#endif
 #endif
 
 found:
-    //printf("[d] got translated block 0x%llx\n", pc);
+#if defined(AFL_DEBUG)
+    printf("[d] got translated block 0x%lx\n", (uint64_t) pc);
+#endif
     /* Move the last found TB to the head of the list */
     if (likely(*ptb1)) {
         *ptb1 = tb->phys_hash_next;

--- a/qemu/target-arm/translate-a64.c
+++ b/qemu/target-arm/translate-a64.c
@@ -35,6 +35,11 @@
 
 #include "exec/gen-icount.h"
 
+#if defined(UNICORN_AFL)
+#undef ARCH_HAS_COMPCOV
+#include "../../afl-unicorn-cpu-translate-inl.h"
+#endif
+
 #ifdef CONFIG_USER_ONLY
 static TCGv_i64 cpu_exclusive_test;
 static TCGv_i32 cpu_exclusive_info;
@@ -11154,6 +11159,11 @@ void gen_intermediate_code_internal_a64(ARMCPU *cpu,
     } else {
         env->uc->size_arg = -1;
     }
+
+#if defined(UNICORN_AFL)
+    /* Generate instrumentation for AFL. */
+    afl_gen_maybe_log(env->uc->tcg_ctx, tb->pc);
+#endif
 
     gen_tb_start(tcg_ctx);
 

--- a/qemu/target-arm/translate.c
+++ b/qemu/target-arm/translate.c
@@ -8222,7 +8222,7 @@ static void disas_arm_insn(DisasContext *s, unsigned int insn)  // qq
             } else {
                 if (set_cc) {
                     gen_sub_CC(s, tmp, tmp, tmp2);
-                    afl_gen_compcov(tcg_ctx, s->pc, tmp, tmp2, MO_32, insn & (1 << 25));
+                    afl_gen_compcov(tcg_ctx, s->pc, (TCGv)tmp, (TCGv)tmp2, MO_32, insn & (1 << 25));
                 } else {
                     tcg_gen_sub_i32(tcg_ctx, tmp, tmp, tmp2);
                 }
@@ -8232,7 +8232,7 @@ static void disas_arm_insn(DisasContext *s, unsigned int insn)  // qq
         case 0x03:
             if (set_cc) {
                 gen_sub_CC(s, tmp, tmp2, tmp);
-                afl_gen_compcov(tcg_ctx, s->pc, tmp, tmp2, MO_32, insn & (1 << 25));
+                afl_gen_compcov(tcg_ctx, s->pc, (TCGv)tmp, (TCGv)tmp2, MO_32, insn & (1 << 25));
             } else {
                 tcg_gen_sub_i32(tcg_ctx, tmp, tmp2, tmp);
             }
@@ -8287,7 +8287,7 @@ static void disas_arm_insn(DisasContext *s, unsigned int insn)  // qq
         case 0x0a:
             if (set_cc) {
                 gen_sub_CC(s, tmp, tmp, tmp2);
-                afl_gen_compcov(tcg_ctx, s->pc, tmp, tmp2, MO_32, insn & (1 << 25));
+                afl_gen_compcov(tcg_ctx, s->pc, (TCGv)tmp, (TCGv)tmp2, MO_32, insn & (1 << 25));
             }
             tcg_temp_free_i32(tcg_ctx, tmp);
             break;
@@ -9208,14 +9208,14 @@ gen_thumb2_data_op(DisasContext *s, int op, int conds, uint32_t shifter_out,
     case 13: /* sub */
         if (conds) {
             gen_sub_CC(s, t0, t0, t1);
-            afl_gen_compcov(tcg_ctx, s->pc, t0, t1, MO_32, has_imm);
+            afl_gen_compcov(tcg_ctx, s->pc, (TCGv)t0, (TCGv)t1, MO_32, has_imm);
         } else
             tcg_gen_sub_i32(tcg_ctx, t0, t0, t1);
         break;
     case 14: /* rsb */
         if (conds) {
             gen_sub_CC(s, t0, t1, t0);
-            afl_gen_compcov(tcg_ctx, s->pc, t0, t1, MO_32, has_imm);
+            afl_gen_compcov(tcg_ctx, s->pc, (TCGv)t0, (TCGv)t1, MO_32, has_imm);
         } else
             tcg_gen_sub_i32(tcg_ctx, t0, t1, t0);
         break;
@@ -10500,7 +10500,7 @@ static void disas_thumb_insn(CPUARMState *env, DisasContext *s) // qq
                     tcg_gen_sub_i32(tcg_ctx, tmp, tmp, tmp2);
                 else {
                     gen_sub_CC(s, tmp, tmp, tmp2);
-                    afl_gen_compcov(tcg_ctx, s->pc, tmp, tmp2, MO_32, insn & (1 << 10));
+                    afl_gen_compcov(tcg_ctx, s->pc, (TCGv)tmp, (TCGv)tmp2, MO_32, insn & (1 << 10));
                 }
             } else {
                 if (s->condexec_mask)
@@ -10538,7 +10538,7 @@ static void disas_thumb_insn(CPUARMState *env, DisasContext *s) // qq
             switch (op) {
             case 1: /* cmp */
                 gen_sub_CC(s, tmp, tmp, tmp2);
-                afl_gen_compcov(tcg_ctx, s->pc, tmp, tmp2, MO_32, 1);
+                afl_gen_compcov(tcg_ctx, s->pc, (TCGv)tmp, (TCGv)tmp2, MO_32, 1);
                 tcg_temp_free_i32(tcg_ctx, tmp);
                 tcg_temp_free_i32(tcg_ctx, tmp2);
                 break;
@@ -10555,7 +10555,7 @@ static void disas_thumb_insn(CPUARMState *env, DisasContext *s) // qq
                     tcg_gen_sub_i32(tcg_ctx, tmp, tmp, tmp2);
                 else {
                     gen_sub_CC(s, tmp, tmp, tmp2);
-                    afl_gen_compcov(tcg_ctx, s->pc, tmp, tmp2, MO_32, 1);
+                    afl_gen_compcov(tcg_ctx, s->pc, (TCGv)tmp, (TCGv)tmp2, MO_32, 1);
                 }
                 tcg_temp_free_i32(tcg_ctx, tmp2);
                 store_reg(s, rd, tmp);
@@ -10594,7 +10594,7 @@ static void disas_thumb_insn(CPUARMState *env, DisasContext *s) // qq
                 tmp = load_reg(s, rd);
                 tmp2 = load_reg(s, rm);
                 gen_sub_CC(s, tmp, tmp, tmp2);
-                afl_gen_compcov(tcg_ctx, s->pc, tmp, tmp2, MO_32, 0);
+                afl_gen_compcov(tcg_ctx, s->pc, (TCGv)tmp, (TCGv)tmp2, MO_32, 0);
                 tcg_temp_free_i32(tcg_ctx, tmp2);
                 tcg_temp_free_i32(tcg_ctx, tmp);
                 break;
@@ -10713,7 +10713,7 @@ static void disas_thumb_insn(CPUARMState *env, DisasContext *s) // qq
             break;
         case 0xa: /* cmp */
             gen_sub_CC(s, tmp, tmp, tmp2);
-            afl_gen_compcov(tcg_ctx, s->pc, tmp, tmp2, MO_32, 0);
+            afl_gen_compcov(tcg_ctx, s->pc, (TCGv)tmp, (TCGv)tmp2, MO_32, 0);
             rd = 16;
             break;
         case 0xb: /* cmn */

--- a/qemu/target-arm/translate.c
+++ b/qemu/target-arm/translate.c
@@ -64,6 +64,7 @@ static TCGv_i32 cpu_exclusive_info;
 #endif
 
 #if defined(UNICORN_AFL)
+#define ARCH_HAS_COMPCOV
 #include "../../afl-unicorn-cpu-translate-inl.h"
 #else
 #define afl_gen_compcov(a,b,c,d,e,f) do {} while (0)
@@ -11323,6 +11324,11 @@ static inline void gen_intermediate_code_internal(ARMCPU *cpu,
     } else {
         env->uc->size_arg = -1;
     }
+
+#if defined(UNICORN_AFL)
+    /* Generate instrumentation for AFL. */
+    afl_gen_maybe_log(env->uc->tcg_ctx, tb->pc);
+#endif
 
     gen_tb_start(tcg_ctx);
 

--- a/qemu/target-i386/translate.c
+++ b/qemu/target-i386/translate.c
@@ -34,6 +34,7 @@
 #include "uc_priv.h"
 
 #if defined(UNICORN_AFL)
+#define ARCH_HAS_COMPCOV
 #include "../../afl-unicorn-cpu-translate-inl.h"
 #else
 #define afl_gen_compcov(a,b,c,d,e,f) do {} while (0)
@@ -8756,6 +8757,11 @@ static inline void gen_intermediate_code_internal(uint8_t *gen_opc_cc_op,
     } else {
         env->uc->size_arg = -1;
     }
+
+#if defined(UNICORN_AFL)
+    /* Generate instrumentation for AFL. */
+    afl_gen_maybe_log(env->uc->tcg_ctx, tb->pc);
+#endif
 
     gen_tb_start(tcg_ctx);
     for(;;) {

--- a/qemu/target-m68k/translate.c
+++ b/qemu/target-m68k/translate.c
@@ -28,6 +28,13 @@
 
 #include "exec/gen-icount.h"
 
+#if defined(UNICORN_AFL)
+#undef ARCH_HAS_COMPCOV
+#include "../../afl-unicorn-cpu-translate-inl.h"
+#endif
+
+
+
 //#define DEBUG_DISPATCH 1
 
 /* Fake floating point.  */
@@ -3144,6 +3151,11 @@ gen_intermediate_code_internal(M68kCPU *cpu, TranslationBlock *tb,
     } else {
         env->uc->size_arg = -1;
     }
+
+#if defined(UNICORN_AFL)
+    /* Generate instrumentation for AFL. */
+    afl_gen_maybe_log(env->uc->tcg_ctx, tb->pc);
+#endif
 
     gen_tb_start(tcg_ctx);
     do {

--- a/qemu/target-m68k/translate.c
+++ b/qemu/target-m68k/translate.c
@@ -1533,7 +1533,7 @@ DISAS_INSN(tas)
     TCGContext *tcg_ctx = s->uc->tcg_ctx;
     TCGv dest;
     TCGv src1;
-    TCGv addr;
+    TCGv addr = 0; // fixes gcc uninitialized warning(?)
 
     dest = tcg_temp_new(tcg_ctx);
     SRC_EA(env, src1, OS_BYTE, 1, &addr);
@@ -1869,7 +1869,7 @@ DISAS_INSN(eor)
     TCGv src;
     TCGv reg;
     TCGv dest;
-    TCGv addr;
+    TCGv addr = 0; // HINT: workaround for maybe-unitialized warning by gcc(?)
 
     SRC_EA(env, src, OS_LONG, 0, &addr);
     reg = DREG(insn, 9);

--- a/qemu/target-mips/translate.c
+++ b/qemu/target-mips/translate.c
@@ -30,6 +30,11 @@
 
 #include "exec/gen-icount.h"
 
+#if defined(UNICORN_AFL)
+#undef ARCH_HAS_COMPCOV
+#include "../../afl-unicorn-cpu-translate-inl.h"
+#endif
+
 #define MIPS_DEBUG_DISAS 0
 //#define MIPS_DEBUG_SIGN_EXTENSIONS
 
@@ -19240,6 +19245,11 @@ gen_intermediate_code_internal(MIPSCPU *cpu, TranslationBlock *tb,
     } else {
         env->uc->size_arg = -1;
     }
+
+#if defined(UNICORN_AFL)
+    /* Generate instrumentation for AFL. */
+    afl_gen_maybe_log(env->uc->tcg_ctx, tb->pc);
+#endif
 
     gen_tb_start(tcg_ctx);
     while (ctx.bstate == BS_NONE) {

--- a/qemu/target-sparc/translate.c
+++ b/qemu/target-sparc/translate.c
@@ -33,6 +33,11 @@
 
 #include "exec/gen-icount.h"
 
+#if defined(UNICORN_AFL)
+#undef ARCH_HAS_COMPCOV
+#include "../../afl-unicorn-cpu-translate-inl.h"
+#endif
+
 #define DYNAMIC_PC  1 /* dynamic pc value */
 #define JUMP_PC     2 /* dynamic pc value which takes only two values
                          according to jump_pc[T2] */
@@ -5453,6 +5458,11 @@ static inline void gen_intermediate_code_internal(SPARCCPU *cpu,
         env->uc->size_arg = tcg_ctx->gen_opparam_buf - tcg_ctx->gen_opparam_ptr + 1;
         gen_uc_tracecode(tcg_ctx, 0xf8f8f8f8, UC_HOOK_BLOCK_IDX, env->uc, pc_start);
     }
+
+#if defined(UNICORN_AFL)
+    /* Generate instrumentation for AFL. */
+    afl_gen_maybe_log(env->uc->tcg_ctx, tb->pc);
+#endif
 
     gen_tb_start(tcg_ctx);
     do {

--- a/qemu/tcg/tcg-runtime.h
+++ b/qemu/tcg/tcg-runtime.h
@@ -15,7 +15,8 @@ DEF_HELPER_FLAGS_2(sar_i64, TCG_CALL_NO_RWG_SE, s64, s64, s64)
 DEF_HELPER_FLAGS_2(mulsh_i64, TCG_CALL_NO_RWG_SE, s64, s64, s64)
 DEF_HELPER_FLAGS_2(muluh_i64, TCG_CALL_NO_RWG_SE, i64, i64, i64)
 
-#ifdef UNICORN_AFL
+#if defined(UNICORN_AFL)
+DEF_HELPER_FLAGS_2(afl_maybe_log, 0, void, ptr, i64)
 DEF_HELPER_FLAGS_4(afl_compcov_log_16, 0, void, ptr, i64, i32, i32)
 DEF_HELPER_FLAGS_4(afl_compcov_log_32, 0, void, ptr, i64, i32, i32)
 DEF_HELPER_FLAGS_4(afl_compcov_log_64, 0, void, ptr, i64, i64, i64)

--- a/qemu/tcg/tcg-runtime.h
+++ b/qemu/tcg/tcg-runtime.h
@@ -16,7 +16,7 @@ DEF_HELPER_FLAGS_2(mulsh_i64, TCG_CALL_NO_RWG_SE, s64, s64, s64)
 DEF_HELPER_FLAGS_2(muluh_i64, TCG_CALL_NO_RWG_SE, i64, i64, i64)
 
 #ifdef UNICORN_AFL
-DEF_HELPER_FLAGS_4(afl_compcov_log_16, 0, void, ptr, i64, i64, i64)
-DEF_HELPER_FLAGS_4(afl_compcov_log_32, 0, void, ptr, i64, i64, i64)
+DEF_HELPER_FLAGS_4(afl_compcov_log_16, 0, void, ptr, i64, i32, i32)
+DEF_HELPER_FLAGS_4(afl_compcov_log_32, 0, void, ptr, i64, i32, i32)
 DEF_HELPER_FLAGS_4(afl_compcov_log_64, 0, void, ptr, i64, i64, i64)
 #endif

--- a/qemu/unicorn_common.h
+++ b/qemu/unicorn_common.h
@@ -90,6 +90,10 @@ static inline void uc_common_init(struct uc_struct* uc)
     uc->exit_count = 0;
     uc->exits = NULL;
     uc->afl_forkserver_start = afl_forkserver_start;
+    uc->afl_child_pipe[0] = 0;
+    uc->afl_child_pipe[1] = 0;
+    uc->afl_parent_pipe[0] = 0;
+    uc->afl_parent_pipe[1] = 0;
     uc->afl_child_request_next = NULL;  // This callback is only set if inside child.
 #endif
 }

--- a/types.h
+++ b/types.h
@@ -101,12 +101,14 @@ typedef int64_t s64;
 
 #define MEM_BARRIER() __asm__ volatile("" ::: "memory")
 
+#ifndef likely
 #if __GNUC__ < 6
 #define likely(_x) (_x)
 #define unlikely(_x) (_x)
 #else
 #define likely(_x) __builtin_expect(!!(_x), 1)
 #define unlikely(_x) __builtin_expect(!!(_x), 0)
+#endif
 #endif
 
 #endif                                                   /* ! _HAVE_TYPES_H */


### PR DESCRIPTION
This commit fixes persistent mode for unicornafl.
The current version only logged in the emulator, however after blocks were chained, AFL no longer got feedback. Now it is patched into the blocks directly, as a helper function.
The commit also includes a rewrite of the forkserver, instead of communicating via signal from child to parent it uses a second pipe.

Since a lot changed, maybe @andreafioraldi can take a quick look before a merge.
A testcase can be found here: https://github.com/vanhauser-thc/AFLplusplus/blob/persistent_test/unicorn_mode/samples/c/harness.c