### PR TITLE
fix error handling of mmap() calls

### DIFF
--- a/qemu/exec.c
+++ b/qemu/exec.c
@@ -1154,7 +1154,7 @@ void qemu_ram_remap(struct uc_struct *uc, ram_addr_t addr, ram_addr_t length)
                     area = mmap(vaddr, length, PROT_READ | PROT_WRITE,
                             flags, -1, 0);
                 }
-                if (area != vaddr) {
+                if (area == MAP_FAILED || area != vaddr) {
                     fprintf(stderr, "Could not remap addr: "
                             RAM_ADDR_FMT "@" RAM_ADDR_FMT "\n",
                             length, addr);

--- a/qemu/translate-all.c
+++ b/qemu/translate-all.c
@@ -439,25 +439,16 @@ static PageDesc *page_find_alloc(struct uc_struct *uc, tb_page_addr_t index, int
 
 #if defined(CONFIG_USER_ONLY)
     /* We can't use g_malloc because it may recurse into a locked mutex. */
-#if defined(UNICORN_AFL)
     /* This was added by unicorn-afl to bail out semi-gracefully if out of memory. */
-# define ALLOC(P, SIZE)                                 \
-    do {                                                \
-        void* _tmp = mmap(NULL, SIZE, PROT_READ | PROT_WRITE,    \
-                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);   \
-        if (_tmp == (void*)-1) { \
-            qemu_log(">>> Out of memory for stack, bailing out. <<<\n"); \
-            exit(1); \
-        } \
-        (P) = _tmp; \
-    } while (0)
-#else /* !UNICORN_AFL */
 # define ALLOC(P, SIZE)                                 \
     do {                                                \
         P = mmap(NULL, SIZE, PROT_READ | PROT_WRITE,    \
                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);   \
+        if (P == MAP_FAILED) { \
+            qemu_log(">>> Out of memory for stack, bailing out. <<<\n"); \
+            exit(1); \
+        } \
     } while (0)
-#endif /* UNICORN_AFL */
 #else
 # define ALLOC(P, SIZE) \
     do { P = g_malloc0(SIZE); } while (0)


### PR DESCRIPTION
small fixes to check the return value of mmap() against MAP_FAILED. @domenukk please report to upstream.